### PR TITLE
Fix parsing when lump entries are not separated by newlines

### DIFF
--- a/lumpmanager.cpp
+++ b/lumpmanager.cpp
@@ -89,7 +89,7 @@ EntityLumpParseResult EntityLumpManager::Parse(const char* pMapEntities) {
 			
 			entry.emplace_back(key, value);
 		}
-		mapEntities >> token;
+		mapEntities.get();
 		m_Entities.push_back(std::make_shared<EntityLumpEntry>(entry));
 	}
 	

--- a/standalone-parser/test_files/no_newlines_between_lumps.ent
+++ b/standalone-parser/test_files/no_newlines_between_lumps.ent
@@ -1,0 +1,23 @@
+{
+"world_maxs" "1408 2104 536"
+"world_mins" "-1408 -2048 -232"
+"skyname" "sky_cs15_daylight02_hdr"
+"maxpropscreenwidth" "-1"
+"detailvbsp" "detail.vbsp"
+"detailmaterial" "detail/detailsprites"
+"classname" "worldspawn"
+"mapversion" "1428"
+"hammerid" "1"
+}{
+"origin" "126 1212 72"
+"priority" "0"
+"angles" "0 292 0"
+"classname" "info_player_terrorist"
+"hammerid" "464742"
+}{
+"origin" "70 1230 72"
+"priority" "0"
+"angles" "0 302.5 0"
+"classname" "info_player_terrorist"
+"hammerid" "464744"
+}


### PR DESCRIPTION
Hey, thanks for this extension :)

Been trying to use it on CS:GO, initially parsing failed on every map.

After a bit of debugging I've found that there are no newlines between lump entries in the engine-provided entities string, so parsing always fails after the first entry.

I'm not sure why this is different from your use case (entities string does have newlines on other games for some reason?), but this fix also makes sense anyway since you're peeking 1 character -> you should consume only 1